### PR TITLE
Add more pooling options, and consolidate utils code to be re-used across various projects

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,7 +1,9 @@
-import trainer.utils.ops as jax_util
-import numpy as onp
-from torch_impl import util as torch_util
 import unittest
+import numpy as onp
+import jax.numpy as jnp
+import trainer.utils.ops as jax_util
+import torch
+from torch_impl import util as torch_util
 
 
 class UtilTest(unittest.TestCase):
@@ -18,3 +20,80 @@ class UtilTest(unittest.TestCase):
             for j in range(len(jax_cos_scores[0])):
                 assert abs(pytorch_cos_scores[i][j] - jax_cos_scores[i][j]) < 0.001, "Output : torch - {}, jax - {}" \
                     .format(pytorch_cos_scores[i], jax_cos_scores[i])
+
+    def test_mean_pooling(self):
+        """Tests the correct computation of mean_pooling"""
+        batch_size = 3
+        max_seq_len = 128
+        embedding_size = 768
+        
+        model_outputs = (onp.random.randn(batch_size, max_seq_len, embedding_size), )
+        attention_mask = onp.random.randint(2, size=(batch_size, max_seq_len))
+
+        model_outputs_pt = torch.tensor(model_outputs)
+        attention_mask_pt = torch.tensor(attention_mask)
+        embeddings_pt = torch_util.mean_pooling(model_outputs_pt, attention_mask_pt)
+
+        model_outputs_jax = jnp.asarray(model_outputs)
+        attention_mask_jax = jnp.asarray(attention_mask)
+        embeddings_jax = jax_util.mean_pooling(model_outputs_jax, attention_mask_jax)    
+                    
+        assert embeddings_pt.numpy().shape == onp.array(embeddings_jax).shape
+        assert onp.all(onp.abs(embeddings_pt.numpy() - onp.array(embeddings_jax)) < 0.001)
+    
+    def test_max_pooling(self):
+        """Tests the correct computation of max_pooling"""
+        batch_size = 3
+        max_seq_len = 128
+        embedding_size = 768
+        
+        model_outputs = (onp.random.randn(batch_size, max_seq_len, embedding_size), )
+        attention_mask = onp.random.randint(2, size=(batch_size, max_seq_len))
+
+        model_outputs_pt = torch.tensor(model_outputs)
+        attention_mask_pt = torch.tensor(attention_mask)
+        embeddings_pt = torch_util.max_pooling(model_outputs_pt, attention_mask_pt)    
+
+        model_outputs_jax = jnp.asarray(model_outputs)
+        attention_mask_jax = jnp.asarray(attention_mask)
+        embeddings_jax = jax_util.max_pooling(model_outputs_jax, attention_mask_jax)
+                    
+        assert embeddings_pt.numpy().shape == onp.array(embeddings_jax).shape
+        assert onp.all(onp.abs(embeddings_pt.numpy() - onp.array(embeddings_jax)) < 0.001)
+
+    def test_max_pooling(self):
+        """Tests the correct computation of max_pooling"""
+        batch_size = 3
+        max_seq_len = 128
+        embedding_size = 768
+        
+        model_outputs = (onp.random.randn(batch_size, max_seq_len, embedding_size), )
+        attention_mask = onp.random.randint(2, size=(batch_size, max_seq_len))
+
+        model_outputs_pt = torch.tensor(model_outputs)
+        attention_mask_pt = torch.tensor(attention_mask)
+        embeddings_pt = torch_util.max_pooling(model_outputs_pt, attention_mask_pt)    
+
+        model_outputs_jax = jnp.asarray(model_outputs)
+        attention_mask_jax = jnp.asarray(attention_mask)
+        embeddings_jax = jax_util.max_pooling(model_outputs_jax, attention_mask_jax)
+                    
+        assert embeddings_pt.numpy().shape == onp.array(embeddings_jax).shape
+        assert onp.all(onp.abs(embeddings_pt.numpy() - onp.array(embeddings_jax)) < 0.001)
+
+    def test_cls_pooling(self):
+        """Tests the correct computation of cls_pooling"""
+        batch_size = 3
+        max_seq_len = 128
+        embedding_size = 768
+        
+        model_outputs = (onp.random.randn(batch_size, max_seq_len, embedding_size), )        
+
+        model_outputs_pt = torch.tensor(model_outputs)        
+        embeddings_pt = torch_util.cls_pooling(model_outputs_pt)    
+
+        model_outputs_jax = jnp.asarray(model_outputs)        
+        embeddings_jax = jax_util.cls_pooling(model_outputs_jax)
+                    
+        assert embeddings_pt.numpy().shape == onp.array(embeddings_jax).shape
+        assert onp.all(onp.abs(embeddings_pt.numpy() - onp.array(embeddings_jax)) < 0.001)        

--- a/torch_impl/util.py
+++ b/torch_impl/util.py
@@ -22,3 +22,27 @@ def cos_sim(a: Tensor, b: Tensor):
     a_norm = torch.nn.functional.normalize(a, p=2, dim=1)
     b_norm = torch.nn.functional.normalize(b, p=2, dim=1)
     return torch.mm(a_norm, b_norm.transpose(0, 1))
+
+def mean_pooling(model_output, attention_mask):
+    """
+    Returns mean pooled embeddings from the last layer of a PyTorch based HuggingFace Transformer model.
+    """
+    embeddings = model_output[0]
+    attention_mask_expanded = attention_mask.unsqueeze(-1).expand(embeddings.shape).float()
+    sum_embeddings = torch.sum(embeddings * attention_mask_expanded, 1)
+    sum_mask = torch.clamp(attention_mask_expanded.sum(1), min=1e-9)
+    return sum_embeddings / sum_mask
+
+def max_pooling(model_output, attention_mask):
+    """
+    Returns max pooled embeddings from the last layer of a PyTorch based HuggingFace Transformer model.
+    """
+    embeddings = model_output[0]
+    attention_mask_expanded = attention_mask.unsqueeze(-1).expand(embeddings.shape).float()    
+    return torch.max(embeddings * attention_mask_expanded, 1).values
+
+def cls_pooling(model_output):
+    """
+    Returns [CLS] token embedding from the last layer of a PyTorch based HuggingFace Transformer model.
+    """
+    return model_output[0][:, 0] # 1st token is the [CLS] token


### PR DESCRIPTION
1. Extended https://github.com/nreimers/flax-sentence-embeddings/pull/5 with more pooling options, and tests  
2. Made the util functions ready to be used by the training scripts of various projects

Will publish a separate PR for integrating the above in the training scripts (so that everyone can re-use the same core modeling code, with the main delta being the datasets)